### PR TITLE
Add option to specify policy package names.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [1.4.7] - 2023-10-12
+- Add option to define package name parameter in OPA Config
+
 ## [1.4.6] - 2023-08-15
 - Update dependencies due to vulnerabilities
   - [certifi](https://github.com/advisories/GHSA-xqr8-7jwr-rhp7)

--- a/fastapi_opa/opa/opa_config.py
+++ b/fastapi_opa/opa/opa_config.py
@@ -28,10 +28,33 @@ class OPAConfig:
         opa_host: str,
         injectables: Optional[List[Injectable]] = None,
         accepted_methods: Optional[List[str]] = ["id_token", "access_token"],
+        package_name: Optional[str] = "httpapi.authz",
     ) -> None:
+        """
+        Configuration container for the OPAMiddleware.
+
+        PARAMETERS
+        ----------
+        authentication: [AuthInterface, List[AuthInterface]]
+            Authentication Implementations to be used for the
+            request authentication.
+        opa_host: str
+            URL to the OPA instance/server.
+        injectables: List[Injectable], default=None
+            List of injectables to be used to add informtation to the
+            OPA request payload.
+        accepted_methods: List[str], default=["id_token", "access_token"]
+            List of accepted authentication methods.
+        package_name: str, default="httpapi.authz
+            Name of the OPA package to be used (specified in the policy).
+        """
+
         if not isinstance(authentication, list):
             authentication = [authentication]
         self.authentication = authentication
-        self.opa_url = f"{opa_host.rstrip('/')}/v1/data/httpapi/authz"
+        self.opa_url = (
+            f"{opa_host.rstrip('/')}/v1/data/{package_name.replace('.', '/')}"
+        )
         self.injectables = injectables
         self.accepted_methods = accepted_methods
+        self.package_name = package_name

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "fastapi-opa"
-version = "1.4.6"
+version = "1.4.7"
 description = "Fastapi OPA middleware incl. auth flow."
 authors = ["Matthias Osswald <info@busykoala.io>"]
 license = "GPL-3.0-or-later"

--- a/tests/test_opa.py
+++ b/tests/test_opa.py
@@ -17,6 +17,20 @@ def test_opa_config():
     assert "localhost/v1/data/httpapi/authz" == opa_conf.opa_url
 
 
+def test_opa_url_uses_package_name():
+    authentication = AuthenticationDummy()
+    opa_conf = OPAConfig(
+        authentication=authentication,
+        opa_host="http://localhost:8181",
+        package_name="kubernetes.admission",
+    )
+
+    assert (
+        "http://localhost:8181/v1/data/kubernetes/admission"
+        == opa_conf.opa_url
+    )
+
+
 def test_successful_opa_flow(client):
     with patch("fastapi_opa.opa.opa_middleware.requests.post") as req:
         req.return_value.status_code = 200


### PR DESCRIPTION
## Purpose

I am using OPA policies with different package names than the currently assumed package httpapi.authz. When doing so, I need the middleware to make a request to a different path instead of v1/data/httpapi/authz to use my policy/package. In order to achieve this, a new parameter is added to the OPAConfig to change the opa_url according to the package name.

## Approach

The new parameter is used to update the opa_url which then points to the expected policy.

## Checklist for PRs

- [x] There is a Changelog (`/CHANGELOG.md`)
- [x] Version was adapted if necessary (`/pyproject.toml`)
- [x] I tested the feature if necessary (unittests, manual testing)
- [x] ~If libraries aren't used for all package usages they are extras~
- [x] I documented the changes

## Learning

See official OPA Data REST Endpoint [docs](https://www.openpolicyagent.org/docs/latest/rest-api/#data-api).

_Links to blog posts, patterns, libraries or addons used to solve this problem_
